### PR TITLE
Fix CORS by using allorigins proxy

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
     </div>
 
     <script>
-        const apiUrl = 'https://www.monomax.me/api/v2/highlights';
+        const apiUrl = "https://api.allorigins.win/get?url=https://www.monomax.me/api/v2/highlights";
 
         const getBtn = document.getElementById('getMovies');
         const table = document.getElementById('movieTable');
@@ -114,6 +114,7 @@
             tbody.innerHTML = '';
             fetch(apiUrl)
                 .then(r => r.json())
+                .then(data => JSON.parse(data.contents))
                 .then(data => {
                     data.data.forEach(movie => {
                         const tr = document.createElement('tr');


### PR DESCRIPTION
## Summary
- use `api.allorigins.win` to bypass CORS for the movie API
- parse returned `contents` JSON from allorigins

## Testing
- `curl -s https://api.allorigins.win/get?url=https://www.monomax.me/api/v2/highlights | jq -r '.contents' | head -c 100`

------
https://chatgpt.com/codex/tasks/task_e_684d3518b4908322bbc79922e6ed78e5